### PR TITLE
Fix for #1

### DIFF
--- a/src/epd7in5.py
+++ b/src/epd7in5.py
@@ -25,7 +25,7 @@
  #
 
 import epdif
-import Image
+from PIL import Image
 import RPi.GPIO as GPIO
 
 # Display resolution
@@ -156,8 +156,8 @@ class EPD:
         self.delay_ms(200)    
 
     def get_frame_buffer(self, image):
-        buf = [0x00] * (self.width * self.height / 8)
-        # buf = [0x00] * int((self.width * self.height / 8))  # To work with python3
+        buf = [0x00] * (self.width * self.height // 8)
+
         # Set buffer to value of Python Imaging Library image.
         # Image must be in mode 1.
         image_monocolor = image.convert('1')
@@ -171,8 +171,7 @@ class EPD:
             for x in range(self.width):
                 # Set the bits for the column of pixels at the current position.
                 if pixels[x, y] != 0:
-                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
-                    # buf[int((x + y * self.width) / 8)] |= 0x80 >> (x % 8)
+                    buf[(x + y * self.width) // 8] |= 0x80 >> (x % 8)
         return buf
 
     def display_frame(self, frame_buffer):


### PR DESCRIPTION
# Cause
The difference is in how integer division is handled between `Python 2.7` vs. `Python 3.4`.

Refer to `epd7in5.py` file, specifically the `get_frame_buffer` function @ line 158.

```Python
def get_frame_buffer(self, image):
        buf = [0x00] * (self.width * self.height / 8)

        # Set buffer to value of Python Imaging Library image.
        # Image must be in mode 1.
        image_monocolor = image.convert('1')
        imwidth, imheight = image_monocolor.size
        if imwidth != self.width or imheight != self.height:
            raise ValueError('Image must be same dimensions as display \
                ({0}x{1}).' .format(self.width, self.height))

        pixels = image_monocolor.load()
        for y in range(self.height):
            for x in range(self.width):
                # Set the bits for the column of pixels at the current position.
                if pixels[x, y] != 0:
                    buf[(x + y * self.width) / 8] |= 0x80 >> (x % 8)
        return buf
```

There are a few instances where we're multiplying the display with x its height / 8. Here's how that looks between python versions:

```Python
# Python 2.7
(640 * 384 / 8) # = 30720

# Python 3.4
(640 * 384 / 8) # = 30720.0
```

# Fix
Simply using the double slash `//` division operator will yield an integer as expected in both version of python.

We want our division to return an `int` in order to multiply by a `byte` array. That cannot be done with a `float`.

```Python
# Python 2.7
(640 * 384 // 8) # = 30720

# Python 3.4
(640 * 384 // 8) # = 30720
```